### PR TITLE
Add ESP32 BME280 InfluxDB sketch

### DIFF
--- a/BME280InfluxSleep/BME280InfluxSleep.ino
+++ b/BME280InfluxSleep/BME280InfluxSleep.ino
@@ -1,0 +1,74 @@
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include <Adafruit_BME280.h>
+#include <WiFi.h>
+#include <InfluxDbClient.h>
+
+// WiFi credentials
+#define WIFI_SSID "REPLACE_WITH_YOUR_SSID"
+#define WIFI_PASSWORD "REPLACE_WITH_YOUR_PASSWORD"
+
+// InfluxDB connection info
+#define INFLUXDB_URL "http://your-influxdb-host:8086"
+#define INFLUXDB_TOKEN "YOUR_TOKEN"
+#define INFLUXDB_ORG "YOUR_ORG"
+#define INFLUXDB_BUCKET "YOUR_BUCKET"
+
+#define SEALEVELPRESSURE_HPA (1013.25)
+
+Adafruit_BME280 bme;          // I2C interface
+InfluxDBClient client(INFLUXDB_URL, INFLUXDB_ORG, INFLUXDB_BUCKET, INFLUXDB_TOKEN);
+Point sensor("environment");
+
+void setup() {
+  Serial.begin(115200);
+
+  // Initialize BME280 sensor
+  if (!bme.begin(0x76)) {  // default I2C address
+    Serial.println("Could not find a valid BME280 sensor, check wiring!");
+    while (1) { delay(10); }
+  }
+
+  // Connect to WiFi
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  Serial.print("Connecting to WiFi");
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print('.');
+  }
+  Serial.println(" connected");
+
+  // Read sensor data
+  float temperature = bme.readTemperature();
+  float humidity = bme.readHumidity();
+  float pressure = bme.readPressure() / 100.0F; // hPa
+
+  sensor.clearFields();
+  sensor.addTag("device", "esp32");
+  sensor.addField("temperature", temperature);
+  sensor.addField("humidity", humidity);
+  sensor.addField("pressure", pressure);
+
+  // Write the data to InfluxDB
+  if (!client.validateConnection()) {
+    Serial.print("InfluxDB connection failed: ");
+    Serial.println(client.getLastErrorMessage());
+  } else {
+    if (!client.writePoint(sensor)) {
+      Serial.print("InfluxDB write failed: ");
+      Serial.println(client.getLastErrorMessage());
+    } else {
+      Serial.println("Data written to InfluxDB");
+    }
+  }
+
+  Serial.println("Entering deep sleep for 30 minutes...");
+  // Sleep for 30 minutes (30 * 60 seconds * 1,000,000 microseconds)
+  esp_sleep_enable_timer_wakeup(30ULL * 60ULL * 1000000ULL);
+  esp_deep_sleep_start();
+}
+
+void loop() {
+  // The ESP32 restarts from setup() after deep sleep, so loop remains empty
+}
+

--- a/BME280InfluxSleep/README.md
+++ b/BME280InfluxSleep/README.md
@@ -1,0 +1,25 @@
+# BME280InfluxSleep
+
+Dieses Beispiel zeigt, wie ein ESP32 über I2C einen BME280 Sensor ausliest und die
+Messwerte über WLAN in eine InfluxDB schreibt. Nach dem Senden der Daten geht
+der ESP32 für 30 Minuten in den Deep-Sleep-Modus, um Energie zu sparen.
+
+## Abhängigkeiten
+
+* [Adafruit BME280 Library](https://github.com/adafruit/Adafruit_BME280_Library)
+* [InfluxDB Client Library for Arduino](https://github.com/tobiasschuerg/InfluxDB-Client-for-Arduino)
+
+Diese Bibliotheken können über den Bibliotheksverwalter der Arduino IDE installiert
+werden.
+
+## Verwendung
+
+1. `WIFI_SSID` und `WIFI_PASSWORD` mit den Daten des eigenen WLAN ersetzen.
+2. `INFLUXDB_URL`, `INFLUXDB_TOKEN`, `INFLUXDB_ORG` und `INFLUXDB_BUCKET`
+   entsprechend der InfluxDB-Konfiguration anpassen.
+3. Sketch auf einen ESP32 laden. Der Sensor wird standardmäßig unter der
+   I2C-Adresse `0x76` erwartet.
+
+Beim Aufwachen misst der ESP32 einmal Temperatur, Luftfeuchtigkeit und
+Luftdruck. Anschließend werden die Werte an InfluxDB gesendet. Danach startet
+der Deep-Sleep-Modus für 30 Minuten.


### PR DESCRIPTION
## Summary
- add example sketch for ESP32 that reads BME280 over I2C
- send measurements to InfluxDB and enter deep sleep for 30 minutes
- include short documentation with required libraries and usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bfe9333fc8327b8f84d5b5046d06f